### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,27 +1,25 @@
-Revision history for Perl extension Array-Iterator.
+Revision history for Perl extension Array-Iterator
 
-0.08     2012-03-28 (Steven Haryanto)
+0.08 2012-03-28 (Steven Haryanto)
 
-         - peek(), look_back(), has_next(), has_previous() now accept optional
-           integer argument for arbitrary lookup, e.g. peek(2) looks at the next
-           next item, peek(1) is the same as peek() (implemented by Alexey
-           Surikov, github#2).
-
-
-0.07     2011-09-09 (Steven Haryanto)
-
-         - Take over maintenance from Stevan Little.
-
-         - Now uses Dist::Zilla and git.
-
-         - Add lowercase method name aliases (has_next() as well as hasNext(),
-           etc). The lowercase method names are now the documented ones.
-
-         - Add iterated() to check whether an iteration has been done (i.e.
-           next(), or get_next(), or previous(), etc has been called).
+     - peek(), look_back(), has_next(), has_previous() now accept optional
+       integer argument for arbitrary lookup, e.g. peek(2) looks at the next
+       next item, peek(1) is the same as peek() (implemented by Alexey
+       Surikov, github#2).
 
 
-0.06 Fri July 8, 2005
+0.07 2011-09-09 (Steven Haryanto)
+
+     - Take over maintenance from Stevan Little.
+     - Now uses Dist::Zilla and git.
+     - Add lowercase method name aliases (has_next() as well as hasNext(),
+       etc). The lowercase method names are now the documented ones.
+     - Add iterated() to check whether an iteration has been done (i.e.
+       next(), or get_next(), or previous(), etc has been called).
+
+
+0.06 2005-07-08
+
     - Fixed bug in Array::Iterator::peek().
       Thanks to Hugo Cornelis for pointing it out
         - added tests for this
@@ -30,7 +28,8 @@ Revision history for Perl extension Array-Iterator.
       constructor option.
         - added tests and docs for this (also from Phillip :)
 
-0.05 Mon July 15, 2004
+0.05 2004-07-15
+
     - added a getLegnth method and tested it
     - changed how currentIndex deals with index of 0, it
       now does it correctly.
@@ -44,7 +43,8 @@ Revision history for Perl extension Array-Iterator.
         - Array::Iterator::Reusable
     - created tests for all these new modules
 
-0.04 Thurs May 6 2004
+0.04 2004-05-06
+
     - Changed current and currentIndex to refer to the
       same value (and index) of the last item dispensed
       by the next method. This is more in line with what
@@ -55,16 +55,19 @@ Revision history for Perl extension Array-Iterator.
       old versions.
     - updated documentation to reflect change
 
-0.03  Sun May 2 2004
+0.03 2004-05-02
+
     - Added currentIndex method, and added tests for it.
     - Added getNext method and added tests for it.
     - altered the behavior of peek to not throw an exception.
     - updated all documentation.
 
-0.02  Mon April 12 2004
+0.02 2004-04-12
+
     - error in the Makefile.PL file, no changes on this release
 
-0.01  Wed Mar 17 23:12:08 2004
+0.01 2004-03-17
+
 	- original version; created by h2xs 1.22 with options
 		-X -n Array::Iterator
 


### PR DESCRIPTION
Hi Steven,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org) - looking there I saw this was your only dist that was non-conformant.

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:
        http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
   You can check the status of your Changes files for all dists:
        http://changes.cpanhq.org/author/SHARYANTO
   If you choose you update the others, you can log them in comments on the quest :-)
